### PR TITLE
INF-33 Add resource limits to Jarvis

### DIFF
--- a/manifests/jarvis-deploy.yaml
+++ b/manifests/jarvis-deploy.yaml
@@ -17,6 +17,13 @@ spec:
       - name: jarvis
         image: @@IMAGE@@
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: "500Mi"
+          limits:
+            cpu: "0.5"
+            memory: "500Mi"
         env:
         - name: JENKINS_USER
           value: bot@devex.com


### PR DESCRIPTION
Now Jarvis will have memory and CPU throttling limits, so it also
appears in our metrics for container limits in Graphana.

Refs [INF-33](https://mydevex.atlassian.net/browse/INF-33)